### PR TITLE
페이스북그룹 공개정보 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ROR Lab.의 공유정신은 웹사이트 리뉴얼에도 그대로 이어져 누
 
 [Wiki](https://github.com/RORLabNew/rorla_api/wiki)
 
-Facebook [루비 온 레일즈 코리아(공개)](https://www.facebook.com/groups/rubyonrailskorea), [리뉴얼(비공개)](https://www.facebook.com/groups/rorlabrenewal)
+Facebook [루비 온 레일즈 코리아(비공개)](https://www.facebook.com/groups/rubyonrailskorea), [리뉴얼(비공개)](https://www.facebook.com/groups/rorlabrenewal)
 
 Development Stack
 -------


### PR DESCRIPTION
페이스북 그룹(루비 온 레일즈 코리아)는  비공개그룹으로 설정되어 있습니다. (Pull request 테스트)
