### PR TITLE
User Spec 추가 : Question, Answer 관계 선언 추가

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -13,4 +13,5 @@ class Answer < ActiveRecord::Base
   validates_presence_of :content
 
   belongs_to :question
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,5 +34,6 @@ class User < ActiveRecord::Base
 
   has_many :posts, foreign_key: :writer_id, dependent: :destroy
   has_many :questions, dependent: :destroy
+  has_many :answers, dependent: :destroy
 
 end

--- a/db/migrate/20140331115522_add_reference_to_answer_for_user.rb
+++ b/db/migrate/20140331115522_add_reference_to_answer_for_user.rb
@@ -1,0 +1,5 @@
+class AddReferenceToAnswerForUser < ActiveRecord::Migration
+  def change
+    add_reference :answers, :user, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,16 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140321101916) do
+ActiveRecord::Schema.define(version: 20140331115522) do
 
   create_table "answers", force: true do |t|
     t.text     "content"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "question_id"
+    t.integer  "user_id"
   end
 
   add_index "answers", ["question_id"], name: "index_answers_on_question_id"
+  add_index "answers", ["user_id"], name: "index_answers_on_user_id"
 
   create_table "auth_tokens", force: true do |t|
     t.integer  "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,18 +86,6 @@ ActiveRecord::Schema.define(version: 20140321101916) do
 
   add_index "questions", ["user_id"], name: "index_questions_on_user_id"
 
-  create_table "scraps", force: true do |t|
-    t.string   "title",                      null: false
-    t.text     "description"
-    t.string   "url",                        null: false
-    t.boolean  "shared",      default: true
-    t.integer  "scraper_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "scraps", ["scraper_id"], name: "index_scraps_on_scraper_id"
-
   create_table "users", force: true do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -34,7 +34,7 @@ describe Question do
       expect(create(:question)).to have_many(:answers)
     end
   end
-  
+
   describe "스코프 및 클래스 메소드 검증"
   describe "인스턴스 메소드 검증"
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -30,15 +30,11 @@ describe Question do
   end
 
   describe "관계선언 검증" do
-    it "> answer를 가질 수 있다." do
-      expect(create(:question_with_answers).answers.first).to be_valid
-    end
-
     it "> 다수의 answer를 가질 수 있다." do
-      expect(create(:question_with_answers, answers_count: 5).answers.count).to eq 5
+      expect(create(:question)).to have_many(:answers)
     end
-
   end
+  
   describe "스코프 및 클래스 메소드 검증"
   describe "인스턴스 메소드 검증"
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,4 +70,13 @@ describe User do
       expect(user).to_not be_valid
     end
   end
+
+  describe "관계선언 검증" do
+    it "> 다수의 question을 가질 수 있다." do
+      expect(create(:user)).to have_many(:questions)
+    end
+  end
+
+  
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,8 +75,14 @@ describe User do
     it "> 다수의 question을 가질 수 있다." do
       expect(create(:user)).to have_many(:questions)
     end
+
+    it "> 다수의 answer를 가질 수 있다." do
+      expect(create(:user)).to have_many(:answers)
+    end
+
+
   end
 
-  
+
 
 end


### PR DESCRIPTION
**1. Question Spec : 관계선언 검증 수정**
- shoulda-matcher의 have_many를 사용하였습니다.

> expect(create(:question)).to have_many(:answers)

<p/>
**2. User Spec : Question 관계 선언 추가**
- 앞서 변경한 부분과 동일하게 관계 선언을 추가하였습니다.

<p/>
**3. User Spec : Answer 관계 선언 추가**
- migration 추가(Answer 모델에 reference 추가)

> add_reference :answers, :user, index: true
- 각 모델에 association 추가
- User Spec에 관계 선언 추가

> expect(create(:user)).to have_many(:answers)

<p/>
**[Shoulda-matcher 요약](http://plaredspear.github.io/blog/2014/03/31/shoulda-matecher-summary)**
