### PR TITLE
Question, Answer Controller Spec : User session 추가

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,7 +1,4 @@
 class AnswersController < ApplicationController
-  # 임시 테스트용
-  skip_before_filter :authenticate_user!
-
   before_action :set_question
   before_action :set_answer, only: [:show, :update, :destroy]
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,7 +1,4 @@
 class QuestionsController < ApplicationController
-  # 임시 테스트용
-  skip_before_filter :authenticate_user!
-
   before_action :set_question, only: [:show, :update, :destroy]
 
   def index

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -10,7 +10,7 @@ describe AnswersController do
   describe 'GET #index' do
     it "> 요청한 Question과 연결된 모든 Answer로 instance 변수를 할당한다." do
       answers = [answer, create(:answer, question: question)]
-      get :index, question_id: question.id
+      do_index
       expect(assigns(:question)).to eq(question)
       expect(assigns(:answers)).to match_array(answers)
     end
@@ -18,7 +18,7 @@ describe AnswersController do
 
   describe 'GET #show' do
     it "> 요청한 Question과 Answer로 instance 변수를 할당한다." do
-      get :show, question_id: question.id, id: answer
+      do_show
       expect(assigns(:question)).to eq(question)
       expect(assigns(:answer)).to eq answer
     end
@@ -26,18 +26,14 @@ describe AnswersController do
 
   describe 'POST #create' do
     context "1) params가 유효할 때" do
-      def do_post
-        post :create, question_id: question.id, answer: valid_attributes
-      end
-
       it "> 새로운 Answer를 생성한다." do
         expect{
-          do_post
+          do_post(valid_attributes)
         }.to change(question.answers, :count).by(1)
       end
 
       it "> 요청한 Question과 새로운 Answer로 instance 변수를 할당한다." do
-        do_post
+        do_post(valid_attributes)
         expect(assigns(:question)).to eq(question)
         expect(assigns(:answer)).to be_a(Answer)
         expect(assigns(:answer)).to_not be_new_record
@@ -45,18 +41,14 @@ describe AnswersController do
     end
 
     context "2) params가 유효하지 않을 때" do
-      def do_post
-        post :create, question_id: question.id, answer: invalid_attributes
-      end
-
       it "> 새로운 Answer를 생성하지 않는다." do
         expect{
-          do_post
+          do_post(invalid_attributes)
         }.to_not change(Answer, :count)
       end
 
       it "> 요청한 Question과 생성하지 못한 Answer로 instance 변수를 할당한다." do
-        do_post
+        do_post(invalid_attributes)
         expect(assigns(:question)).to eq(question)
         expect(assigns(:answer)).to be_a(Answer)
         expect(assigns(:answer)).to be_new_record
@@ -66,39 +58,26 @@ describe AnswersController do
 
   describe 'PATCH #update' do
     context "1) params가 유효할 때" do
-      def do_patch
-        patch :update, question_id: question.id, id: answer,
-          answer: attributes_for(:answer, content: "Answer content changed")
-      end
-
       it "> 요청한 Answer를 업데이트한다." do
-        do_patch
-        answer.reload
+        do_patch(attributes_for(:answer, content: "Answer content changed"))
         expect(answer.content).to eq "Answer content changed"
       end
       
       it "> 요청한 Question과 Answer로 instance 변수를 할당한다." do
-        do_patch
-        answer.reload
+        do_patch(attributes_for(:answer, content: "Answer content changed"))
         expect(assigns(:question)).to eq(question)
         expect(assigns(:answer)).to eq answer
       end
     end
 
     context "2) params가 유효하지 않을 때" do
-      def do_patch
-        patch :update, question_id: question.id, id: answer, answer: invalid_attributes
-      end
-
       it "> 요청한 answer를 업데이트하지 않는다." do
-        do_patch
-        answer.reload
+        do_patch(invalid_attributes)
         expect(answer.content).to eq "Answer Content"
       end
 
       it "> 요청한 Question과 Answer로 instance 변수를 할당한다." do
-        do_patch
-        answer.reload
+        do_patch(invalid_attributes)
         expect(assigns(:question)).to eq(question)
         expect(assigns(:answer)).to eq answer
       end
@@ -108,10 +87,6 @@ describe AnswersController do
   describe 'DELETE #destroy' do
     before(:each) do
       @answer = create(:answer, question: question)
-    end
-
-    def do_delete
-      delete :destroy, question_id: question.id, id: @answer
     end
 
     it "> 요청한 answer를 삭제한다." do
@@ -125,6 +100,32 @@ describe AnswersController do
       expect(assigns(:question)).to eq(question)
       expect(assigns(:answer)).to eq(@answer)
     end
+  end
+
+
+
+  private
+
+  def do_index
+    get :index, question_id: question.id
+  end
+
+  def do_show
+    get :show, question_id: question.id, id: answer
+  end
+
+  def do_post(attributes={})
+    post :create, question_id: question.id, answer: attributes
+  end
+
+  def do_patch(attributes={})
+    patch :update, question_id: question.id, id: answer,
+      answer: attributes
+    answer.reload
+  end
+
+  def do_delete
+    delete :destroy, question_id: question.id, id: @answer
   end
 
 end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -7,98 +7,131 @@ describe AnswersController do
   let(:valid_attributes) { attributes_for(:answer) } 
   let(:invalid_attributes) { attributes_for(:answer, content: nil) }
 
-  describe 'GET #index' do
-    it "> 요청한 Question과 연결된 모든 Answer로 instance 변수를 할당한다." do
-      answers = [answer, create(:answer, question: question)]
-      do_index
-      expect(assigns(:question)).to eq(question)
-      expect(assigns(:answers)).to match_array(answers)
-    end
-  end
-
-  describe 'GET #show' do
-    it "> 요청한 Question과 Answer로 instance 변수를 할당한다." do
-      do_show
-      expect(assigns(:question)).to eq(question)
-      expect(assigns(:answer)).to eq answer
-    end
-  end
-
-  describe 'POST #create' do
-    context "1) params가 유효할 때" do
-      it "> 새로운 Answer를 생성한다." do
-        expect{
-          do_post(valid_attributes)
-        }.to change(question.answers, :count).by(1)
+  describe 'User 로그인' do
+    context "> 로그인 상태" do
+      before :each do
+        current_user = create(:user)
+        current_user.confirm!
+        sign_in current_user
       end
 
-      it "> 요청한 Question과 새로운 Answer로 instance 변수를 할당한다." do
-        do_post(valid_attributes)
-        expect(assigns(:question)).to eq(question)
-        expect(assigns(:answer)).to be_a(Answer)
-        expect(assigns(:answer)).to_not be_new_record
+      describe 'GET #index' do
+        it "> 요청한 Question과 연결된 모든 Answer로 instance 변수를 할당한다." do
+          answers = [answer, create(:answer, question: question)]
+          do_index
+          expect(assigns(:question)).to eq(question)
+          expect(assigns(:answers)).to match_array(answers)
+        end
+      end
+
+      describe 'GET #show' do
+        it "> 요청한 Question과 Answer로 instance 변수를 할당한다." do
+          do_show
+          expect(assigns(:question)).to eq(question)
+          expect(assigns(:answer)).to eq answer
+        end
+      end
+
+      describe 'POST #create' do
+        context "1) params가 유효할 때" do
+          it "> 새로운 Answer를 생성한다." do
+            expect{
+              do_post(valid_attributes)
+            }.to change(question.answers, :count).by(1)
+          end
+
+          it "> 요청한 Question과 새로운 Answer로 instance 변수를 할당한다." do
+            do_post(valid_attributes)
+            expect(assigns(:question)).to eq(question)
+            expect(assigns(:answer)).to be_a(Answer)
+            expect(assigns(:answer)).to_not be_new_record
+          end
+        end
+
+        context "2) params가 유효하지 않을 때" do
+          it "> 새로운 Answer를 생성하지 않는다." do
+            expect{
+              do_post(invalid_attributes)
+            }.to_not change(Answer, :count)
+          end
+
+          it "> 요청한 Question과 생성하지 못한 Answer로 instance 변수를 할당한다." do
+            do_post(invalid_attributes)
+            expect(assigns(:question)).to eq(question)
+            expect(assigns(:answer)).to be_a(Answer)
+            expect(assigns(:answer)).to be_new_record
+          end
+        end
+      end
+
+      describe 'PATCH #update' do
+        context "1) params가 유효할 때" do
+          it "> 요청한 Answer를 업데이트한다." do
+            do_patch(attributes_for(:answer, content: "Answer content changed"))
+            expect(answer.content).to eq "Answer content changed"
+          end
+          
+          it "> 요청한 Question과 Answer로 instance 변수를 할당한다." do
+            do_patch(attributes_for(:answer, content: "Answer content changed"))
+            expect(assigns(:question)).to eq(question)
+            expect(assigns(:answer)).to eq answer
+          end
+        end
+
+        context "2) params가 유효하지 않을 때" do
+          it "> 요청한 answer를 업데이트하지 않는다." do
+            do_patch(invalid_attributes)
+            expect(answer.content).to eq "Answer Content"
+          end
+
+          it "> 요청한 Question과 Answer로 instance 변수를 할당한다." do
+            do_patch(invalid_attributes)
+            expect(assigns(:question)).to eq(question)
+            expect(assigns(:answer)).to eq answer
+          end
+        end
+      end
+
+      describe 'DELETE #destroy' do
+        before(:each) do
+          @answer = create(:answer, question: question)
+        end
+
+        it "> 요청한 answer를 삭제한다." do
+          expect {
+            do_delete
+          }.to change(Answer, :count).by(-1)
+        end
+
+        it "> 요청한 Question과 삭제된 Answer로 instance 변수를 할당한다." do
+          do_delete
+          expect(assigns(:question)).to eq(question)
+          expect(assigns(:answer)).to eq(@answer)
+        end
       end
     end
 
-    context "2) params가 유효하지 않을 때" do
-      it "> 새로운 Answer를 생성하지 않는다." do
-        expect{
-          do_post(invalid_attributes)
-        }.to_not change(Answer, :count)
+    context "> 비로그인 상태" do
+      describe 'GET #index' do
+        it "> 비로그인 메시지를 할당한다."
       end
 
-      it "> 요청한 Question과 생성하지 못한 Answer로 instance 변수를 할당한다." do
-        do_post(invalid_attributes)
-        expect(assigns(:question)).to eq(question)
-        expect(assigns(:answer)).to be_a(Answer)
-        expect(assigns(:answer)).to be_new_record
-      end
-    end
-  end
-
-  describe 'PATCH #update' do
-    context "1) params가 유효할 때" do
-      it "> 요청한 Answer를 업데이트한다." do
-        do_patch(attributes_for(:answer, content: "Answer content changed"))
-        expect(answer.content).to eq "Answer content changed"
-      end
-      
-      it "> 요청한 Question과 Answer로 instance 변수를 할당한다." do
-        do_patch(attributes_for(:answer, content: "Answer content changed"))
-        expect(assigns(:question)).to eq(question)
-        expect(assigns(:answer)).to eq answer
-      end
-    end
-
-    context "2) params가 유효하지 않을 때" do
-      it "> 요청한 answer를 업데이트하지 않는다." do
-        do_patch(invalid_attributes)
-        expect(answer.content).to eq "Answer Content"
+      describe 'GET #show' do
+        it "> 비로그인 메시지를 할당한다."
       end
 
-      it "> 요청한 Question과 Answer로 instance 변수를 할당한다." do
-        do_patch(invalid_attributes)
-        expect(assigns(:question)).to eq(question)
-        expect(assigns(:answer)).to eq answer
+      describe 'POST #create' do
+        it "> 비로그인 메시지를 할당한다."
       end
-    end
-  end
 
-  describe 'DELETE #destroy' do
-    before(:each) do
-      @answer = create(:answer, question: question)
-    end
+      describe 'PATCH #update' do
+        it "비로그인 메시지를 할당한다."
+      end
 
-    it "> 요청한 answer를 삭제한다." do
-      expect {
-        do_delete
-      }.to change(Answer, :count).by(-1)
-    end
+      describe 'DELETE #destroy' do
+        it "비로그인 메시지를 할당한다."
+      end
 
-    it "> 요청한 Question과 삭제된 Answer로 instance 변수를 할당한다." do
-      do_delete
-      expect(assigns(:question)).to eq(question)
-      expect(assigns(:answer)).to eq(@answer)
     end
   end
 

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -6,91 +6,124 @@ describe QuestionsController do
   let(:valid_attributes) { attributes_for(:question) }
   let(:invalid_attributes) { attributes_for(:question, title: nil) }
 
-  describe 'GET #index' do
-    it "> 모든 Question으로 instance 변수를 할당한다." do
-      questions = [question, create(:question)]
-      do_index
-      expect(assigns(:questions)).to match_array(questions)
+  describe 'User 로그인' do
+    context "> 로그인 상태" do
+      before :each do
+        current_user = create(:user)
+        current_user.confirm!
+        sign_in current_user
+      end
+
+      describe 'GET #index' do
+        it "> 모든 Question으로 instance 변수를 할당한다." do
+          questions = [question, create(:question)]
+          do_index
+          expect(assigns(:questions)).to match_array(questions)
+        end
+      end
+
+      describe 'GET #show' do
+        it "> 요청한 Question으로 instance 변수를 할당한다." do
+          do_show
+          expect(assigns(:question)).to eq question
+        end
+      end
+
+      describe 'POST #create' do
+        context "1) params가 유효할 때" do
+          it "> 새로운 Question을 생성한다." do
+            expect {
+              do_post(valid_attributes)
+            }.to change(Question, :count).by(1)
+          end
+
+          it "> 새로운 Question으로 instance 변수를 할당한다." do
+            do_post(valid_attributes)
+            expect(assigns(:question)).to be_a(Question)
+            expect(assigns(:question)).to_not be_new_record
+          end
+        end
+
+        context "2) params가 유효하지 않을 때" do
+          it "> 새로운 Quesiton을 생성하지 않는다." do
+            expect {
+              do_post(invalid_attributes)
+            }.to_not change(Question, :count)
+          end
+
+          it "> 새로운 Question을 instance 변수에 할당한다." do
+            do_post(invalid_attributes)
+            expect(assigns(:question)).to be_a(Question)
+            expect(assigns(:question)).to be_new_record
+          end
+        end
+      end
+
+      describe 'PATCH #update' do
+        context "1) params가 유효할 때" do
+          it "> 요청한 question을 업데이트한다." do
+            do_patch(attributes_for(:question, title: "Wonderfulday isn't it?", content: "Yes!!!"))
+            expect(question.title).to eq("Wonderfulday isn't it?")
+            expect(question.content).to eq("Yes!!!")
+          end
+
+          it "> 요청한 question을 instance 변수에 할당한다." do
+            do_patch(attributes_for(:question, title: "Wonderfulday isn't it?", content: "Yes!!!"))
+            expect(assigns(:question)).to eq question
+          end
+        end
+
+        context "2) params가 유효하지 않을 때" do
+          it "> 요청한 quesiton을 업데이트하지 않는다." do
+            do_patch(invalid_attributes)
+            expect(question.title).to eq("Question Title")
+            expect(question.content).to eq("Question Content")
+          end
+
+          it "> 요청한 question을 instance 변수에 할당한다." do
+            do_patch(invalid_attributes)
+            expect(assigns(:question)).to eq question
+          end
+        end
+      end
+
+      describe 'DELETE #destroy' do
+        before(:each) { question }
+
+        it "> 요청한 Question을 삭제한다." do
+          expect {
+            do_delete
+          }.to change(Question, :count).by(-1)
+        end
+
+        it "> 요청한 Question으로 instance 변수를 할당한다." do
+          do_delete
+          expect(assigns(:question)).to eq question
+        end
+      end
     end
-  end
 
-  describe 'GET #show' do
-    it "> 요청한 Question으로 instance 변수를 할당한다." do
-      do_show
-      expect(assigns(:question)).to eq question
-    end
-  end
-
-  describe 'POST #create' do
-    context "1) params가 유효할 때" do
-      it "> 새로운 Question을 생성한다." do
-        expect {
-          do_post(valid_attributes)
-        }.to change(Question, :count).by(1)
+    context "> 비로그인 상태" do
+      describe 'GET #index' do
+        it "> 비로그인 메시지를 할당한다."
       end
 
-      it "> 새로운 Question으로 instance 변수를 할당한다." do
-        do_post(valid_attributes)
-        expect(assigns(:question)).to be_a(Question)
-        expect(assigns(:question)).to_not be_new_record
-      end
-    end
-
-    context "2) params가 유효하지 않을 때" do
-      it "> 새로운 Quesiton을 생성하지 않는다." do
-        expect {
-          do_post(invalid_attributes)
-        }.to_not change(Question, :count)
+      describe 'GET #show' do
+        it "> 비로그인 메시지를 할당한다."
       end
 
-      it "> 새로운 Question을 instance 변수에 할당한다." do
-        do_post(invalid_attributes)
-        expect(assigns(:question)).to be_a(Question)
-        expect(assigns(:question)).to be_new_record
-      end
-    end
-  end
-
-  describe 'PATCH #update' do
-    context "1) params가 유효할 때" do
-      it "> 요청한 question을 업데이트한다." do
-        do_patch(attributes_for(:question, title: "Wonderfulday isn't it?", content: "Yes!!!"))
-        expect(question.title).to eq("Wonderfulday isn't it?")
-        expect(question.content).to eq("Yes!!!")
+      describe 'POST #create' do
+        it "> 비로그인 메시지를 할당한다."
       end
 
-      it "> 요청한 question을 instance 변수에 할당한다." do
-        do_patch(attributes_for(:question, title: "Wonderfulday isn't it?", content: "Yes!!!"))
-        expect(assigns(:question)).to eq question
-      end
-    end
-
-    context "2) params가 유효하지 않을 때" do
-      it "> 요청한 quesiton을 업데이트하지 않는다." do
-        do_patch(invalid_attributes)
-        expect(question.title).to eq("Question Title")
-        expect(question.content).to eq("Question Content")
+      describe 'PATCH #update' do
+        it "비로그인 메시지를 할당한다."
       end
 
-      it "> 요청한 question을 instance 변수에 할당한다." do
-        do_patch(invalid_attributes)
-        expect(assigns(:question)).to eq question
+      describe 'DELETE #destroy' do
+        it "비로그인 메시지를 할당한다."
       end
-    end
-  end
 
-  describe 'DELETE #destroy' do
-    before(:each) { question }
-
-    it "> 요청한 Question을 삭제한다." do
-      expect {
-        do_delete
-      }.to change(Question, :count).by(-1)
-    end
-
-    it "> 요청한 Question으로 instance 변수를 할당한다." do
-      do_delete
-      expect(assigns(:question)).to eq question
     end
   end
 
@@ -118,4 +151,5 @@ describe QuestionsController do
   def do_delete
     delete :destroy, id: question
   end
+
 end

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -9,42 +9,42 @@ describe QuestionsController do
   describe 'GET #index' do
     it "> 모든 Question으로 instance 변수를 할당한다." do
       questions = [question, create(:question)]
-      get :index
+      do_index
       expect(assigns(:questions)).to match_array(questions)
     end
   end
 
   describe 'GET #show' do
     it "> 요청한 Question으로 instance 변수를 할당한다." do
-      get :show, id: question
+      do_show
       expect(assigns(:question)).to eq question
     end
   end
 
   describe 'POST #create' do
     context "1) params가 유효할 때" do
-      it "> 새로운 question을 생성한다." do
+      it "> 새로운 Question을 생성한다." do
         expect {
-          post :create, question: valid_attributes
+          do_post(valid_attributes)
         }.to change(Question, :count).by(1)
       end
 
-      it "> 새로운 question으로 instance 변수를 할당한다." do
-        post :create, question: valid_attributes
+      it "> 새로운 Question으로 instance 변수를 할당한다." do
+        do_post(valid_attributes)
         expect(assigns(:question)).to be_a(Question)
         expect(assigns(:question)).to_not be_new_record
       end
     end
 
     context "2) params가 유효하지 않을 때" do
-      it "> 새로운 quesiton을 생성하지 않는다." do
+      it "> 새로운 Quesiton을 생성하지 않는다." do
         expect {
-          post :create, question: invalid_attributes
+          do_post(invalid_attributes)
         }.to_not change(Question, :count)
       end
 
-      it "> 새로운 question을 instance 변수에 할당한다." do
-        post :create, question: invalid_attributes
+      it "> 새로운 Question을 instance 변수에 할당한다." do
+        do_post(invalid_attributes)
         expect(assigns(:question)).to be_a(Question)
         expect(assigns(:question)).to be_new_record
       end
@@ -54,43 +54,68 @@ describe QuestionsController do
   describe 'PATCH #update' do
     context "1) params가 유효할 때" do
       it "> 요청한 question을 업데이트한다." do
-        patch :update, id: question, question: attributes_for(:question, title: "Wonderfulday isn't it?", content: "Yes!!!")
-        question.reload
+        do_patch(attributes_for(:question, title: "Wonderfulday isn't it?", content: "Yes!!!"))
         expect(question.title).to eq("Wonderfulday isn't it?")
         expect(question.content).to eq("Yes!!!")
       end
 
       it "> 요청한 question을 instance 변수에 할당한다." do
-        patch :update, id: question, question: valid_attributes
-        question.reload
+        do_patch(attributes_for(:question, title: "Wonderfulday isn't it?", content: "Yes!!!"))
         expect(assigns(:question)).to eq question
       end
     end
 
     context "2) params가 유효하지 않을 때" do
       it "> 요청한 quesiton을 업데이트하지 않는다." do
-        patch :update, id: question, question: invalid_attributes
-        question.reload
+        do_patch(invalid_attributes)
         expect(question.title).to eq("Question Title")
         expect(question.content).to eq("Question Content")
       end
 
       it "> 요청한 question을 instance 변수에 할당한다." do
-        patch :update, id: question, question: invalid_attributes
-        question.reload
+        do_patch(invalid_attributes)
         expect(assigns(:question)).to eq question
       end
     end
-    
   end
 
   describe 'DELETE #destroy' do
-    it "> 요청한 question을 삭제한다." do
-      question
+    before(:each) { question }
+
+    it "> 요청한 Question을 삭제한다." do
       expect {
-        delete :destroy, id: question
+        do_delete
       }.to change(Question, :count).by(-1)
+    end
+
+    it "> 요청한 Question으로 instance 변수를 할당한다." do
+      do_delete
+      expect(assigns(:question)).to eq question
     end
   end
 
+
+
+  private
+
+  def do_index
+    get :index
+  end
+
+  def do_show
+    get :show, id: question
+  end
+
+  def do_post(attributes={})
+    post :create, question: attributes
+  end
+
+  def do_patch(attributes={})
+    patch :update, id: question, question: attributes
+    question.reload
+  end
+  
+  def do_delete
+    delete :destroy, id: question
+  end
 end

--- a/spec/features/answer_management_spec.rb
+++ b/spec/features/answer_management_spec.rb
@@ -15,10 +15,12 @@ feature "Answer management" do
     create(:answer, question: question, user: user,
                     id: 3702, content: "Answer 2",
                     created_at: datetime, updated_at: datetime)
+    user.confirm!
+    @header = { "X-Auth-Email" => user.email, "X-Auth-Token" => user.generate_auth_token! }
   end
 
   scenario "> 한 질문에 달린 답변 목록을 얻는다" do
-    get "/questions/37/answers.json"
+    get "/questions/37/answers.json", nil, @header
     expect(json).to include({
       id: 3701,
       question_id: 37,
@@ -38,7 +40,7 @@ feature "Answer management" do
   end
 
   scenario "> 한 답변의 상세 정보를 얻는다" do
-    get "/questions/37/answers/3701.json"
+    get "/questions/37/answers/3701.json", nil, @header
     expect(json).to include({
       id: 3701,
       question_id: 37,
@@ -50,21 +52,21 @@ feature "Answer management" do
   end
 
   scenario "> 질문에 대한 답변을 작성한다" do
-    post "/questions/37/answers.json", answer: {content: "Do It Yourself"}
+    post "/questions/37/answers.json", {answer: {content: "Do It Yourself"}}, @header
     expect(json).to include({
       content: "Do It Yourself"
     }.with_indifferent_access)
   end
 
   scenario "> 답변을 수정한다" do
-    put "/questions/37/answers/3701.json", answer: {content: "Hacked"}
+    put "/questions/37/answers/3701.json", {answer: {content: "Hacked"}}, @header
     expect(json).to include({
       content: "Hacked"
     }.with_indifferent_access)
   end
 
   scenario "> 답변을 삭제한다" do
-    delete "/questions/37/answers/3701.json"
+    delete "/questions/37/answers/3701.json", nil, @header
     expect(json).to include({
       message: "destroyed"
     }.with_indifferent_access)


### PR DESCRIPTION
### 1. Question, Answer Controller Spec 리팩토링

**가독성을 높이기위해, 각 Controller 메소드를 간소화함.**

```
describe 'GET #index' do
  it "> 모든 Question으로 instance 변수를 할당한다." do
    questions = [question, create(:question)]
    do_index
    expect(assigns(:questions)).to match_array(questions)
  end
end

...

private

def do_index
  get :index
end
```
### 2. Question, Answer Controller Spec : User session 추가

-Controller Spec에 User session 부분을 추가함.
-Feature Scenario : token으로 session 처리를 하기에 header에 token 정보를 추가해줘야함.

```
user.confirm!
@header = { "X-Auth-Email" => user.email, "X-Auth-Token" => user.generate_auth_token! }

...

get "/questions/37/answers.json", nil, @header
```

<br/>
#### **_Todo : Signed in 되지 않은 User에 대한 처리**_
