### PR TITLE
게시판 분류(Bulletin) 생성

### DIFF
--- a/app/models/bulletin.rb
+++ b/app/models/bulletin.rb
@@ -1,0 +1,6 @@
+class Bulletin < ActiveRecord::Base
+  has_many :posts
+
+  validates_length_of :title, maximum: 64
+  validates_uniqueness_of :title
+end

--- a/db/migrate/20140513125302_create_bulletins.rb
+++ b/db/migrate/20140513125302_create_bulletins.rb
@@ -1,0 +1,10 @@
+class CreateBulletins < ActiveRecord::Migration
+  def change
+    create_table :bulletins do |t|
+      t.string :title
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20140513132642_add_bulletin_id_to_posts.rb
+++ b/db/migrate/20140513132642_add_bulletin_id_to_posts.rb
@@ -1,0 +1,5 @@
+
+  def change
+    add_column :posts, :bulletin_id, :integer
+  end
+end

--- a/db/migrate/20140515041020_add_title_uniqueness_index.rb
+++ b/db/migrate/20140515041020_add_title_uniqueness_index.rb
@@ -1,0 +1,9 @@
+class AddTitleUniquenessIndex < ActiveRecord::Migration
+  def self.up
+    add_index :bulletins, :title, unique: true
+  end
+
+  def self.down
+    remove_index :bulletins, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,6 +33,13 @@ ActiveRecord::Schema.define(version: 20140410141400) do
 
   add_index "auth_tokens", ["user_id"], name: "index_auth_tokens_on_user_id"
 
+  create_table "bulletins", force: true do |t|
+    t.string   "title"
+    t.string   "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "comments", force: true do |t|
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140410141400) do
+ActiveRecord::Schema.define(version: 20140515041020) do
 
   create_table "answers", force: true do |t|
     t.text     "content"
@@ -39,6 +39,8 @@ ActiveRecord::Schema.define(version: 20140410141400) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "bulletins", ["title"], name: "index_bulletins_on_title", unique: true
 
   create_table "comments", force: true do |t|
     t.datetime "created_at"
@@ -88,6 +90,7 @@ ActiveRecord::Schema.define(version: 20140410141400) do
     t.datetime "published_at"
     t.integer  "hit",          default: 0
     t.datetime "deleted_at"
+    t.integer  "bulletin_id"
   end
 
   add_index "posts", ["writer_id"], name: "index_posts_on_writer_id"

--- a/spec/factories/bulletins.rb
+++ b/spec/factories/bulletins.rb
@@ -1,0 +1,8 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :bulletin do
+    title "자유게시판"
+    description "누구나 게시 열람할 수 있습니다."
+  end
+end

--- a/spec/models/bulletin_spec.rb
+++ b/spec/models/bulletin_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Bulletin do
+
+  describe "> 유효성 검증" do
+    it { should have_many(:posts) }
+
+    # it { should have_many(:posts).dependent(:destory) }
+
+    describe "> 게시판 제목은" do
+
+      it "너무 길면 안된다." do
+        wrong_bulletin = build(:bulletin)
+        wrong_bulletin.title = "공지사항" * 25
+        wrong_bulletin.should_not be_valid
+      end
+
+      it "겹쳐서 만들 수 없다." do
+        create(:bulletin)
+        twin = build(:bulletin)
+        twin.should_not be_valid
+      end
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -7,5 +7,6 @@ describe Post do
     it "> Content가 없으면 유효하지 않다."
     it "> 4개의 Comment를 가지고 있다."
     it "> Post 생성시 hit는 0이다."
+    it "> 1개의 User를 가지고 있다."
   end
 end


### PR DESCRIPTION
포스트 등에 대한 주제별로 게시판을 묶을 수 있도록 모델을 생성합니다. 기존 사이트에서 Category 입니다. Bulletin은 제목과 설명을 구성하였습니다. published, published_at 에 대한 스펙을 추가 예정입니다.
