### PR TITLE
Hotfix - AddBulletinIdToPosts migration error

### DIFF
--- a/db/migrate/20140513132642_add_bulletin_id_to_posts.rb
+++ b/db/migrate/20140513132642_add_bulletin_id_to_posts.rb
@@ -1,4 +1,4 @@
-
+class AddBulletinIdToPosts < ActiveRecord::Migration
   def change
     add_column :posts, :bulletin_id, :integer
   end


### PR DESCRIPTION
AddBulletinIdToPosts 클래스 선언이 안 되어 migration이 안 됨.
=> 클래스 선언 추가
